### PR TITLE
feat(persistent store): add a key-value store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ dependencies = [
  "state",
  "structopt",
  "tokio",
- "tonic",
+ "tonic 0.1.1",
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
@@ -843,7 +843,7 @@ dependencies = [
  "mbus_api",
  "rpc",
  "tokio",
- "tonic",
+ "tonic 0.1.1",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1099,6 +1099,8 @@ dependencies = [
  "nats",
  "paste",
  "rpc",
+ "serde_json",
+ "store",
  "structopt",
  "strum",
  "strum_macros",
@@ -1251,6 +1253,19 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "etcd-client"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b5b71a6f57f7977f70f84082070e1b2aaaaa5b327c4146505296dcd5de7e59"
+dependencies = [
+ "http",
+ "prost",
+ "tokio",
+ "tonic 0.3.1",
+ "tonic-build 0.3.1",
 ]
 
 [[package]]
@@ -1438,6 +1453,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "generator"
+version = "0.6.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fed24fd1e18827652b4d55652899a1e9da8e54d91624dc3437a5bc3a9f9a9c"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1822,6 +1850,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0e8460f2f2121162705187214720353c517b97bdfb3494c0b1e33d83ebe4bed"
+dependencies = [
+ "cfg-if 0.1.10",
+ "generator",
+ "scoped-tls",
+]
+
+[[package]]
 name = "lru-cache"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2115,6 +2154,15 @@ name = "once_cell"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+
+[[package]]
+name = "oneshot"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39d7085e4e51b36df4afa83db60d20ad2adf8e8587a193f93c9143bf7b375dec"
+dependencies = [
+ "loom",
+]
 
 [[package]]
 name = "opaque-debug"
@@ -2860,8 +2908,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "tonic",
- "tonic-build",
+ "tonic 0.1.1",
+ "tonic-build 0.1.1",
 ]
 
 [[package]]
@@ -2917,6 +2965,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2931,6 +2985,12 @@ dependencies = [
  "lazy_static",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "scopeguard"
@@ -3316,6 +3376,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
+name = "store"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "composer",
+ "etcd-client",
+ "oneshot",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3670,10 +3745,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74a5d6e7439ecf910463667080de772a9c7ddf26bc9fb4f3252ac3862e43337d"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64 0.12.3",
+ "bytes 0.5.6",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "percent-encoding 2.1.0",
+ "pin-project 0.4.27",
+ "prost",
+ "prost-derive",
+ "tokio",
+ "tokio-util 0.3.1",
+ "tower",
+ "tower-balance",
+ "tower-load",
+ "tower-make",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
 name = "tonic-build"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0436413ba71545bcc6c2b9a0f9d78d72deb0123c6a75ccdfe7c056f9930f5e52"
+dependencies = [
+ "proc-macro2",
+ "prost-build",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19970cf58f3acc820962be74c4021b8bbc8e8a1c4e3a02095d0aa60cde5f3633"
 dependencies = [
  "proc-macro2",
  "prost-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "control-plane/rest",
     "control-plane/macros",
     "control-plane/deployer",
+    "control-plane/store",
 # Test mayastor through the rest api
     "tests-mayastor",
 ]

--- a/control-plane/deployer/Cargo.toml
+++ b/control-plane/deployer/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/lib.rs"
 [dependencies]
 mbus_api = { path = "../mbus-api" }
 composer = { path = "../../composer" }
+store = { path = "../store" }
 nats = "0.8"
 structopt = "0.3.15"
 tokio = { version = "0.2", features = ["full"] }
@@ -25,3 +26,4 @@ rpc = "0.1.0"
 strum = "0.19"
 strum_macros = "0.19"
 paste = "1.0.4"
+serde_json = "1.0"

--- a/control-plane/deployer/src/infra/etcd.rs
+++ b/control-plane/deployer/src/infra/etcd.rs
@@ -1,0 +1,60 @@
+use super::*;
+use store::{etcd::Etcd as EtcdStore, kv_store::Store};
+
+#[async_trait]
+impl ComponentAction for Etcd {
+    fn configure(
+        &self,
+        options: &StartOptions,
+        cfg: Builder,
+    ) -> Result<Builder, Error> {
+        Ok(if options.etcd {
+            cfg.add_container_spec(
+                ContainerSpec::from_binary(
+                    "etcd",
+                    Binary::from_nix("etcd").with_args(vec![
+                        "--data-dir",
+                        "/tmp/etcd-data",
+                        "--advertise-client-urls",
+                        "http://0.0.0.0:2379",
+                        "--listen-client-urls",
+                        "http://0.0.0.0:2379",
+                    ]),
+                )
+                .with_portmap("2379", "2379")
+                .with_portmap("2380", "2380"),
+            )
+        } else {
+            cfg
+        })
+    }
+    async fn start(
+        &self,
+        options: &StartOptions,
+        cfg: &ComposeTest,
+    ) -> Result<(), Error> {
+        if options.etcd {
+            cfg.start("etcd").await?;
+        }
+        Ok(())
+    }
+    async fn wait_on(
+        &self,
+        options: &StartOptions,
+        _cfg: &ComposeTest,
+    ) -> Result<(), Error> {
+        if options.etcd {
+            let mut store = EtcdStore::new("0.0.0.0:2379")
+                .await
+                .expect("Failed to connect to etcd.");
+            let key = serde_json::json!("wait");
+            let value = serde_json::json!("test");
+            store
+                .put(&key, &value)
+                .await
+                .expect("Failed to 'put' to etcd");
+            store.delete(&key).await.unwrap();
+        }
+        Ok(())
+    }
+}

--- a/control-plane/deployer/src/infra/mod.rs
+++ b/control-plane/deployer/src/infra/mod.rs
@@ -1,5 +1,6 @@
 pub mod dns;
 mod empty;
+mod etcd;
 mod jaeger;
 mod mayastor;
 mod nats;
@@ -325,6 +326,7 @@ impl_component! {
     // to make sure that the IP does not change between tests
     Nats,       0,
     Dns,        1,
+    Etcd,       1,
     Jaeger,     1,
     Rest,       2,
     Core,       3,

--- a/control-plane/deployer/src/lib.rs
+++ b/control-plane/deployer/src/lib.rs
@@ -106,6 +106,10 @@ pub struct StartOptions {
     /// Name of the cluster - currently only one allowed at a time
     #[structopt(short, long, default_value = DEFAULT_CLUSTER_NAME)]
     pub cluster_name: String,
+
+    /// Start an etcd cluster
+    #[structopt(short, long)]
+    pub etcd: bool,
 }
 
 impl StartOptions {
@@ -139,6 +143,10 @@ impl StartOptions {
         base_image: impl Into<Option<String>>,
     ) -> Self {
         self.base_image = base_image.into();
+        self
+    }
+    pub fn with_etcd(mut self, etcd: bool) -> Self {
+        self.etcd = etcd;
         self
     }
 }

--- a/control-plane/store/Cargo.toml
+++ b/control-plane/store/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "store"
+version = "0.1.0"
+authors = ["Paul Yoong <paul.yoong@mayadata.io>"]
+edition = "2018"
+description = "A key-value store"
+
+[dependencies]
+etcd-client = "0.5.5"
+tokio = { version = "0.2", features = ["full"] }
+serde_json = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+async-trait = "0.1.36"
+snafu = "0.6"
+tracing = "0.1"
+
+[dev-dependencies]
+composer = { path = "../../composer" }
+oneshot = "0.1.2"

--- a/control-plane/store/README.md
+++ b/control-plane/store/README.md
@@ -1,0 +1,7 @@
+# Control Plane Store
+
+A key-value (kv) store has been chosen to persist control plane information. Such information includes:
+- Configuration
+- Per-volume policies i.e. replica replacement policy
+
+etcd has been chosen as the kv store due to its wide adoption and familiarity.

--- a/control-plane/store/src/etcd.rs
+++ b/control-plane/store/src/etcd.rs
@@ -1,0 +1,168 @@
+use crate::kv_store::{
+    Connect,
+    Delete,
+    DeserialiseKey,
+    DeserialiseValue,
+    Get,
+    KeyString,
+    Put,
+    Store,
+    StoreError,
+    StoreError::MissingEntry,
+    ValueString,
+    Watch,
+    WatchEvent,
+};
+use async_trait::async_trait;
+use etcd_client::{Client, EventType, KeyValue, WatchStream, Watcher};
+use serde_json::Value;
+use snafu::ResultExt;
+use tokio::sync::mpsc::{channel, Receiver, Sender};
+
+/// etcd client
+pub struct Etcd(Client);
+
+impl Etcd {
+    /// Create a new instance of the etcd client
+    pub async fn new(endpoint: &str) -> Result<Self, StoreError> {
+        Ok(Self(
+            Client::connect([endpoint], None)
+                .await
+                .context(Connect {})?,
+        ))
+    }
+}
+
+#[async_trait]
+impl Store for Etcd {
+    /// 'Put' a key-value pair into etcd.
+    async fn put(
+        &mut self,
+        key: &Value,
+        value: &Value,
+    ) -> Result<(), StoreError> {
+        self.0
+            .put(key.to_string(), value.to_string(), None)
+            .await
+            .context(Put {
+                key: key.to_string(),
+                value: value.to_string(),
+            })?;
+        Ok(())
+    }
+
+    /// 'Get' the value for the given key from etcd.
+    async fn get(&mut self, key: &Value) -> Result<Value, StoreError> {
+        let resp = self.0.get(key.to_string(), None).await.context(Get {
+            key: key.to_string(),
+        })?;
+        match resp.kvs().first() {
+            Some(kv) => {
+                let v = kv.value_str().context(ValueString {})?;
+                Ok(serde_json::from_str(v).context(DeserialiseValue {
+                    value: v.to_string(),
+                })?)
+            }
+            None => Err(MissingEntry {
+                key: key.to_string(),
+            }),
+        }
+    }
+
+    /// 'Delete' the entry with the given key from etcd.
+    async fn delete(&mut self, key: &Value) -> Result<(), StoreError> {
+        self.0.delete(key.to_string(), None).await.context(Delete {
+            key: key.to_string(),
+        })?;
+        Ok(())
+    }
+
+    /// 'Watch' the etcd entry with the given key.
+    /// A receiver channel is returned which is signalled when the entry with
+    /// the given key is changed.
+    async fn watch(
+        &mut self,
+        key: &Value,
+    ) -> Result<Receiver<Result<WatchEvent, StoreError>>, StoreError> {
+        let (sender, receiver) = channel(100);
+        let (watcher, stream) =
+            self.0.watch(key.to_string(), None).await.context(Watch {
+                key: key.to_string(),
+            })?;
+        watch(watcher, stream, sender);
+        Ok(receiver)
+    }
+}
+
+/// Watch for events in the key-value store.
+/// When an event occurs, a WatchEvent is sent over the channel.
+/// When a 'delete' event is received, the watcher stops watching.
+fn watch(
+    _watcher: Watcher,
+    mut stream: WatchStream,
+    mut sender: Sender<Result<WatchEvent, StoreError>>,
+) {
+    // For now we spawn a thread for each value that is watched.
+    // If we find that we are watching lots of events, this can be optimised.
+    // TODO: Optimise the spawning of threads if required.
+    tokio::spawn(async move {
+        loop {
+            let response = match stream.message().await {
+                Ok(msg) => {
+                    match msg {
+                        Some(resp) => resp,
+                        // If there is no message, continue to wait for the
+                        // next one.
+                        None => continue,
+                    }
+                }
+                Err(e) => {
+                    // If we failed to get a message, continue to wait for the
+                    // next one.
+                    tracing::error!("Failed to get message with error {}", e);
+                    continue;
+                }
+            };
+
+            for event in response.events() {
+                match event.event_type() {
+                    EventType::Put => {
+                        if let Some(kv) = event.kv() {
+                            let result = match deserialise_kv(&kv) {
+                                Ok((key, value)) => {
+                                    Ok(WatchEvent::Put(key, value))
+                                }
+                                Err(e) => Err(e),
+                            };
+                            if sender.send(result).await.is_err() {
+                                // Send only fails if the receiver is closed, so
+                                // just stop watching.
+                                return;
+                            }
+                        }
+                    }
+                    EventType::Delete => {
+                        // Send only fails if the receiver is closed. We are
+                        // returning here anyway, so the error doesn't need to
+                        // be handled.
+                        let _ = sender.send(Ok(WatchEvent::Delete)).await;
+                        return;
+                    }
+                }
+            }
+        }
+    });
+}
+
+/// Deserialise a key-value pair into serde_json::Value representations.
+fn deserialise_kv(kv: &KeyValue) -> Result<(Value, Value), StoreError> {
+    let key_str = kv.key_str().context(KeyString {})?;
+    let key = serde_json::from_str(key_str).context(DeserialiseKey {
+        key: key_str.to_string(),
+    })?;
+    let value_str = kv.value_str().context(ValueString {})?;
+    let value = serde_json::from_str(value_str).context(DeserialiseValue {
+        value: value_str.to_string(),
+    })?;
+    Ok((key, value))
+}

--- a/control-plane/store/src/kv_store.rs
+++ b/control-plane/store/src/kv_store.rs
@@ -1,0 +1,95 @@
+use async_trait::async_trait;
+use etcd_client::Error;
+use serde_json::{Error as SerdeError, Value};
+use snafu::Snafu;
+use tokio::sync::mpsc::Receiver;
+
+/// Definition of errors that can be returned from the key-value store.
+#[derive(Debug, Snafu)]
+#[snafu(visibility = "pub(crate)")]
+pub enum StoreError {
+    /// Failed to connect to the key-value store.
+    #[snafu(display("Failed to connect to store. Error {}", source))]
+    Connect { source: Error },
+    /// Failed to 'put' an entry in the store.
+    #[snafu(display(
+        "Failed to 'put' entry with key {} and value {}. Error {}",
+        key,
+        value,
+        source
+    ))]
+    Put {
+        key: String,
+        value: String,
+        source: Error,
+    },
+    /// Failed to 'get' an entry from the store.
+    #[snafu(display(
+        "Failed to 'get' entry with key {}. Error {}",
+        key,
+        source
+    ))]
+    Get { key: String, source: Error },
+    /// Failed to find an entry with the given key.
+    #[snafu(display("Entry with key {} not found.", key))]
+    MissingEntry { key: String },
+    /// Failed to 'delete' an entry from the store.
+    #[snafu(display(
+        "Failed to 'delete' entry with key {}. Error {}",
+        key,
+        source
+    ))]
+    Delete { key: String, source: Error },
+    /// Failed to 'watch' an entry in the store.
+    #[snafu(display(
+        "Failed to 'watch' entry with key {}. Error {}",
+        key,
+        source
+    ))]
+    Watch { key: String, source: Error },
+    /// Empty key.
+    #[snafu(display("Failed to get key as string. Error {}", source))]
+    KeyString { source: Error },
+    /// Failed to deserialise key.
+    #[snafu(display("Failed to deserialise key {}. Error {}", key, source))]
+    DeserialiseKey { key: String, source: SerdeError },
+    /// Empty value.
+    #[snafu(display("Failed to get value as string. Error {}", source))]
+    ValueString { source: Error },
+    /// Failed to deserialise value.
+    #[snafu(display(
+        "Failed to deserialise value {}. Error {}",
+        value,
+        source
+    ))]
+    DeserialiseValue { value: String, source: SerdeError },
+}
+
+/// Representation of a watch event.
+pub enum WatchEvent {
+    // Put operation containing the key and value
+    Put(Value, Value),
+    // Delete operation
+    Delete,
+}
+
+/// Trait defining the operations that can be performed on a key-value store.
+#[async_trait]
+pub trait Store {
+    /// Put entry into the store.
+    async fn put(
+        &mut self,
+        key: &Value,
+        value: &Value,
+    ) -> Result<(), StoreError>;
+    /// Get an entry from the store.
+    async fn get(&mut self, key: &Value) -> Result<Value, StoreError>;
+    /// Delete an entry from the store.
+    async fn delete(&mut self, key: &Value) -> Result<(), StoreError>;
+    /// Watch for changes to the entry with the given key.
+    /// Returns a channel which will be signalled when an event occurs.
+    async fn watch(
+        &mut self,
+        key: &Value,
+    ) -> Result<Receiver<Result<WatchEvent, StoreError>>, StoreError>;
+}

--- a/control-plane/store/src/lib.rs
+++ b/control-plane/store/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod etcd;
+pub mod kv_store;

--- a/control-plane/store/tests/etcd.rs
+++ b/control-plane/store/tests/etcd.rs
@@ -1,0 +1,150 @@
+use composer::{Binary, Builder, ContainerSpec};
+use oneshot::Receiver;
+use serde::{Deserialize, Serialize};
+use std::{
+    net::{SocketAddr, TcpStream},
+    str::FromStr,
+    thread::sleep,
+    time::Duration,
+};
+use store::{
+    etcd::Etcd,
+    kv_store::{Store, WatchEvent},
+};
+use tokio::task::JoinHandle;
+
+static ETCD_ENDPOINT: &str = "0.0.0.0:2379";
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct TestStruct {
+    name: String,
+    value: u64,
+    msg: String,
+}
+
+#[tokio::test]
+async fn etcd() {
+    let _test = Builder::new()
+        .name("etcd")
+        .add_container_spec(
+            ContainerSpec::from_binary(
+                "etcd",
+                Binary::from_nix("etcd").with_args(vec![
+                    "--data-dir",
+                    "/tmp/etcd-data",
+                    "--advertise-client-urls",
+                    "http://0.0.0.0:2379",
+                    "--listen-client-urls",
+                    "http://0.0.0.0:2379",
+                ]),
+            )
+            .with_portmap("2379", "2379")
+            .with_portmap("2380", "2380"),
+        )
+        .build()
+        .await
+        .unwrap();
+
+    assert!(wait_for_etcd_ready(ETCD_ENDPOINT).is_ok(), "etcd not ready");
+
+    let mut store = Etcd::new(ETCD_ENDPOINT)
+        .await
+        .expect("Failed to connect to etcd.");
+
+    let key = serde_json::json!("key");
+    let mut data = TestStruct {
+        name: "John Doe".to_string(),
+        value: 100,
+        msg: "Hello etcd".to_string(),
+    };
+
+    // Add an entry to the store, read it back and make sure it is correct.
+    store
+        .put(&key, &serde_json::json!(&data))
+        .await
+        .expect("Failed to 'put' to etcd");
+    let v = store.get(&key).await.expect("Failed to 'get' from etcd");
+    let result: TestStruct =
+        serde_json::from_value(v).expect("Failed to deserialise value");
+    assert_eq!(data, result);
+
+    // Start a watcher which should send a message when the subsequent 'put'
+    // event occurs.
+    let (put_hdl, r) = spawn_watcher(&key, &mut store).await;
+
+    // Modify entry.
+    data.value = 200;
+    store
+        .put(&key, &serde_json::json!(&data))
+        .await
+        .expect("Failed to 'put' to etcd");
+
+    // Wait up to 1 second for the watcher to see the put event.
+    let msg = r
+        .recv_timeout(Duration::from_secs(1))
+        .expect("Timed out waiting for message");
+    let result: TestStruct = match msg {
+        WatchEvent::Put(_k, v) => {
+            serde_json::from_value(v).expect("Failed to deserialise value")
+        }
+        _ => panic!("Expected a 'put' event"),
+    };
+    assert_eq!(result, data);
+
+    // Start a watcher which should send a message when the subsequent 'delete'
+    // event occurs.
+    let (del_hdl, r) = spawn_watcher(&key, &mut store).await;
+    store.delete(&key).await.unwrap();
+
+    // Wait up to 1 second for the watcher to see the delete event.
+    let msg = r
+        .recv_timeout(Duration::from_secs(1))
+        .expect("Timed out waiting for message");
+    match msg {
+        WatchEvent::Delete => {
+            // The entry is deleted. Let's check that a subsequent 'get' fails.
+            store
+                .get(&key)
+                .await
+                .expect_err("Entry should have been deleted");
+        }
+        _ => panic!("Expected a 'delete' event"),
+    };
+
+    put_hdl.await.unwrap();
+    del_hdl.await.unwrap();
+}
+
+/// Spawn a watcher thread which watches for a single change to the entry with
+/// the given key.
+async fn spawn_watcher(
+    key: &serde_json::Value,
+    store: &mut dyn Store,
+) -> (JoinHandle<()>, Receiver<WatchEvent>) {
+    let (s, r) = oneshot::channel();
+    let mut watcher = store.watch(&key).await.expect("Failed to watch");
+    let hdl = tokio::spawn(async move {
+        match watcher.recv().await.unwrap() {
+            Ok(event) => {
+                s.send(event).unwrap();
+            }
+            Err(_) => {
+                panic!("Failed to receive event");
+            }
+        }
+    });
+    (hdl, r)
+}
+
+/// Wait to establish a connection to etcd.
+/// Returns 'Ok' if connected otherwise 'Err' is returned.
+fn wait_for_etcd_ready(endpoint: &str) -> Result<(), ()> {
+    let sa = SocketAddr::from_str(endpoint).unwrap();
+    for _ in 1 .. 10 {
+        if TcpStream::connect_timeout(&sa, Duration::from_millis(100)).is_ok() {
+            return Ok(());
+        }
+        sleep(Duration::from_millis(500));
+    }
+    Err(())
+}

--- a/shell.nix
+++ b/shell.nix
@@ -33,6 +33,7 @@ mkShell {
     utillinux
     which
     docker
+    etcd
   ]
   ++ pkgs.lib.optional (!norust) channel.nightly.rust
   ++ pkgs.lib.optional (!nomayastor) mayastor.units.debug.mayastor;


### PR DESCRIPTION
Include support for a key-value store which can be used by the control
plane to persist information.

etcd has been selected as the key-value store to use.

Add deployer support for etcd. To launch etcd include the '--etcd'
argument.

Resolves: CAS-765