### PR TITLE
refactor(remove panic): return error for ANA

### DIFF
--- a/control-plane/agents/common/src/errors.rs
+++ b/control-plane/agents/common/src/errors.rs
@@ -83,6 +83,8 @@ pub enum SvcError {
     MBusError { source: mbus_api::Error },
     #[snafu(display("Invalid Arguments"))]
     InvalidArguments {},
+    #[snafu(display("Multiple nexuses not supported"))]
+    MultipleNexuses {},
 }
 
 impl From<mbus_api::Error> for SvcError {
@@ -250,6 +252,14 @@ impl From<SvcError> for ReplyError {
             SvcError::MBusError {
                 source,
             } => source.into(),
+            SvcError::MultipleNexuses {
+                ..
+            } => ReplyError {
+                kind: ReplyErrorKind::InvalidArgument,
+                resource: ResourceKind::Unknown,
+                source: desc.to_string(),
+                extra: error.full_string(),
+            },
         }
     }
 }

--- a/control-plane/agents/core/src/volume/service.rs
+++ b/control-plane/agents/core/src/volume/service.rs
@@ -207,8 +207,10 @@ impl Service {
             return Err(SvcError::InvalidArguments {});
         }
 
+        // TODO: Remove check when ANA support is added.
         if request.nexuses > 1 {
-            panic!("ANA volumes is not currently supported");
+            tracing::error!("ANA volumes are not currently supported");
+            return Err(SvcError::MultipleNexuses {});
         }
 
         // filter pools according to the following criteria (any order):


### PR DESCRIPTION
Support for ANA is not yet implemented, however it is possible when
creating a volume to specify multiple nexuses. Rather than panicking
when this occurs, return an appropriate error.