### PR TITLE
fix: map actix builtin errors to our control plane errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2231,7 +2231,7 @@ dependencies = [
 [[package]]
 name = "paperclip"
 version = "0.5.0"
-source = "git+https://github.com/MayastorControlPlane/paperclip?branch=develop#2220457419e62d42d9b93e43d9b34b510925dd26"
+source = "git+https://github.com/MayastorControlPlane/paperclip?branch=develop#27933e0b37b79cf36b9881615a3759b6b3cdbaa0"
 dependencies = [
  "anyhow",
  "itertools 0.10.0",
@@ -2240,7 +2240,7 @@ dependencies = [
  "paperclip-core",
  "paperclip-macros",
  "parking_lot",
- "semver 0.11.0",
+ "semver",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2252,7 +2252,7 @@ dependencies = [
 [[package]]
 name = "paperclip-actix"
 version = "0.3.0"
-source = "git+https://github.com/MayastorControlPlane/paperclip?branch=develop#2220457419e62d42d9b93e43d9b34b510925dd26"
+source = "git+https://github.com/MayastorControlPlane/paperclip?branch=develop#27933e0b37b79cf36b9881615a3759b6b3cdbaa0"
 dependencies = [
  "actix-service",
  "actix-web",
@@ -2267,7 +2267,7 @@ dependencies = [
 [[package]]
 name = "paperclip-core"
 version = "0.3.0"
-source = "git+https://github.com/MayastorControlPlane/paperclip?branch=develop#2220457419e62d42d9b93e43d9b34b510925dd26"
+source = "git+https://github.com/MayastorControlPlane/paperclip?branch=develop#27933e0b37b79cf36b9881615a3759b6b3cdbaa0"
 dependencies = [
  "actix-web",
  "mime",
@@ -2285,7 +2285,7 @@ dependencies = [
 [[package]]
 name = "paperclip-macros"
 version = "0.4.0"
-source = "git+https://github.com/MayastorControlPlane/paperclip?branch=develop#2220457419e62d42d9b93e43d9b34b510925dd26"
+source = "git+https://github.com/MayastorControlPlane/paperclip?branch=develop#27933e0b37b79cf36b9881615a3759b6b3cdbaa0"
 dependencies = [
  "heck",
  "http",
@@ -2358,15 +2358,6 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
-
-[[package]]
-name = "pest"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
-dependencies = [
- "ucd-trie",
-]
 
 [[package]]
 name = "petgraph"
@@ -2936,7 +2927,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver 0.9.0",
+ "semver",
 ]
 
 [[package]]
@@ -3037,16 +3028,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser 0.7.0",
-]
-
-[[package]]
-name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser 0.10.2",
+ "semver-parser",
 ]
 
 [[package]]
@@ -3054,15 +3036,6 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "serde"
@@ -4126,12 +4099,6 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-bidi"

--- a/control-plane/rest/service/src/v0/block_devices.rs
+++ b/control-plane/rest/service/src/v0/block_devices.rs
@@ -22,7 +22,7 @@ pub(super) fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
 //      curl -X GET "https://localhost:8080/v0/nodes/mayastor/block_devices" \
 //      -H  "accept: application/json" -k
 //
-#[get("/v0", "/nodes/{node}/block_devices", tags(BlockDevices))]
+#[get("/nodes/{node}/block_devices", tags(BlockDevices))]
 async fn get_block_devices(
     web::Query(info): web::Query<GetBlockDeviceQueryParams>,
     web::Path(node): web::Path<NodeId>,

--- a/control-plane/rest/service/src/v0/children.rs
+++ b/control-plane/rest/service/src/v0/children.rs
@@ -11,20 +11,20 @@ pub(super) fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
         .service(delete_node_nexus_child);
 }
 
-#[get("/v0", "/nexuses/{nexus_id}/children", tags(Children))]
+#[get("/nexuses/{nexus_id}/children", tags(Children))]
 async fn get_nexus_children(
     web::Path(nexus_id): web::Path<NexusId>,
 ) -> Result<web::Json<Vec<Child>>, RestError> {
     get_children_response(Filter::Nexus(nexus_id)).await
 }
-#[get("/v0", "/nodes/{node_id}/nexuses/{nexus_id}/children", tags(Children))]
+#[get("/nodes/{node_id}/nexuses/{nexus_id}/children", tags(Children))]
 async fn get_node_nexus_children(
     web::Path((node_id, nexus_id)): web::Path<(NodeId, NexusId)>,
 ) -> Result<web::Json<Vec<Child>>, RestError> {
     get_children_response(Filter::NodeNexus(node_id, nexus_id)).await
 }
 
-#[get("/v0", "/nexuses/{nexus_id}/children/{child_id:.*}", tags(Children))]
+#[get("/nexuses/{nexus_id}/children/{child_id:.*}", tags(Children))]
 async fn get_nexus_child(
     web::Path((nexus_id, child_id)): web::Path<(NexusId, ChildUri)>,
     req: HttpRequest,
@@ -32,7 +32,6 @@ async fn get_nexus_child(
     get_child_response(child_id, req, Filter::Nexus(nexus_id)).await
 }
 #[get(
-    "/v0",
     "/nodes/{node_id}/nexuses/{nexus_id}/children/{child_id:.*}",
     tags(Children)
 )]
@@ -48,7 +47,7 @@ async fn get_node_nexus_child(
         .await
 }
 
-#[put("/v0", "/nexuses/{nexus_id}/children/{child_id:.*}", tags(Children))]
+#[put("/nexuses/{nexus_id}/children/{child_id:.*}", tags(Children))]
 async fn add_nexus_child(
     web::Path((nexus_id, child_id)): web::Path<(NexusId, ChildUri)>,
     req: HttpRequest,
@@ -56,7 +55,6 @@ async fn add_nexus_child(
     add_child_filtered(child_id, req, Filter::Nexus(nexus_id)).await
 }
 #[put(
-    "/v0",
     "/nodes/{node_id}/nexuses/{nexus_id}/children/{child_id:.*}",
     tags(Children)
 )]
@@ -72,7 +70,7 @@ async fn add_node_nexus_child(
         .await
 }
 
-#[delete("/v0", "/nexuses/{nexus_id}/children/{child_id:.*}", tags(Children))]
+#[delete("/nexuses/{nexus_id}/children/{child_id:.*}", tags(Children))]
 async fn delete_nexus_child(
     web::Path((nexus_id, child_id)): web::Path<(NexusId, ChildUri)>,
     req: HttpRequest,
@@ -80,7 +78,6 @@ async fn delete_nexus_child(
     delete_child_filtered(child_id, req, Filter::Nexus(nexus_id)).await
 }
 #[delete(
-    "/v0",
     "/nodes/{node_id}/nexuses/{nexus_id}/children/{child_id:.*}",
     tags(Children)
 )]

--- a/control-plane/rest/service/src/v0/jsongrpc.rs
+++ b/control-plane/rest/service/src/v0/jsongrpc.rs
@@ -18,7 +18,7 @@ pub(crate) fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
 //  -H "accept: application/json" -H "Content-Type: application/json" \
 //  -d '{"block_size": 512, "num_blocks": 64, "name": "Malloc0"}'
 // ```
-#[put("/v0", "/nodes/{node}/jsongrpc/{method}", tags(JsonGrpc))]
+#[put("/nodes/{node}/jsongrpc/{method}", tags(JsonGrpc))]
 async fn json_grpc_call(
     web::Path((node, method)): web::Path<(NodeId, JsonGrpcMethod)>,
     body: web::Json<JsonGeneric>,

--- a/control-plane/rest/service/src/v0/mod.rs
+++ b/control-plane/rest/service/src/v0/mod.rs
@@ -60,6 +60,19 @@ fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
     block_devices::configure(cfg);
 }
 
+fn json_error(
+    err: impl std::fmt::Display,
+    _req: &actix_web::HttpRequest,
+) -> actix_web::Error {
+    RestError::from(ReplyError {
+        kind: ReplyErrorKind::DeserializeReq,
+        resource: ResourceKind::Unknown,
+        source: "".to_string(),
+        extra: err.to_string(),
+    })
+    .into()
+}
+
 pub(super) fn configure_api<T, B>(
     api: actix_web::App<T, B>,
 ) -> actix_web::App<T, B>
@@ -79,7 +92,16 @@ where
         .service(
             // any /v0 services must either live within this scope or be
             // declared beforehand
-            paperclip::actix::web::scope("/v0").configure(configure),
+            paperclip::actix::web::scope("/v0")
+                .app_data(
+                    actix_web::web::PathConfig::default()
+                        .error_handler(|e, r| json_error(e, r)),
+                )
+                .app_data(
+                    actix_web::web::JsonConfig::default()
+                        .error_handler(|e, r| json_error(e, r)),
+                )
+                .configure(configure),
         )
         .trim_base_path()
         .with_raw_json_spec(|app, spec| {

--- a/control-plane/rest/service/src/v0/nexuses.rs
+++ b/control-plane/rest/service/src/v0/nexuses.rs
@@ -12,25 +12,25 @@ pub(super) fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
         .service(del_node_nexus_share);
 }
 
-#[get("/v0", "/nexuses", tags(Nexuses))]
+#[get("/nexuses", tags(Nexuses))]
 async fn get_nexuses() -> Result<Json<Vec<Nexus>>, RestClusterError> {
     RestRespond::result(MessageBus::get_nexuses(Filter::None).await)
         .map_err(RestClusterError::from)
 }
-#[get("/v0", "/nexuses/{nexus_id}", tags(Nexuses))]
+#[get("/nexuses/{nexus_id}", tags(Nexuses))]
 async fn get_nexus(
     web::Path(nexus_id): web::Path<NexusId>,
 ) -> Result<Json<Nexus>, RestError> {
     RestRespond::result(MessageBus::get_nexus(Filter::Nexus(nexus_id)).await)
 }
 
-#[get("/v0", "/nodes/{id}/nexuses", tags(Nexuses))]
+#[get("/nodes/{id}/nexuses", tags(Nexuses))]
 async fn get_node_nexuses(
     web::Path(node_id): web::Path<NodeId>,
 ) -> Result<Json<Vec<Nexus>>, RestError> {
     RestRespond::result(MessageBus::get_nexuses(Filter::Node(node_id)).await)
 }
-#[get("/v0", "/nodes/{node_id}/nexuses/{nexus_id}", tags(Nexuses))]
+#[get("/nodes/{node_id}/nexuses/{nexus_id}", tags(Nexuses))]
 async fn get_node_nexus(
     web::Path((node_id, nexus_id)): web::Path<(NodeId, NexusId)>,
 ) -> Result<Json<Nexus>, RestError> {
@@ -39,7 +39,7 @@ async fn get_node_nexus(
     )
 }
 
-#[put("/v0", "/nodes/{node_id}/nexuses/{nexus_id}", tags(Nexuses))]
+#[put("/nodes/{node_id}/nexuses/{nexus_id}", tags(Nexuses))]
 async fn put_node_nexus(
     web::Path((node_id, nexus_id)): web::Path<(NodeId, NexusId)>,
     create: web::Json<CreateNexusBody>,
@@ -48,24 +48,20 @@ async fn put_node_nexus(
     RestRespond::result(MessageBus::create_nexus(create).await)
 }
 
-#[delete("/v0", "/nodes/{node_id}/nexuses/{nexus_id}", tags(Nexuses))]
+#[delete("/nodes/{node_id}/nexuses/{nexus_id}", tags(Nexuses))]
 async fn del_node_nexus(
     web::Path((node_id, nexus_id)): web::Path<(NodeId, NexusId)>,
 ) -> Result<JsonUnit, RestError> {
     destroy_nexus(Filter::NodeNexus(node_id, nexus_id)).await
 }
-#[delete("/v0", "/nexuses/{nexus_id}", tags(Nexuses))]
+#[delete("/nexuses/{nexus_id}", tags(Nexuses))]
 async fn del_nexus(
     web::Path(nexus_id): web::Path<NexusId>,
 ) -> Result<JsonUnit, RestError> {
     destroy_nexus(Filter::Nexus(nexus_id)).await
 }
 
-#[put(
-    "/v0",
-    "/nodes/{node_id}/nexuses/{nexus_id}/share/{protocol}",
-    tags(Nexuses)
-)]
+#[put("/nodes/{node_id}/nexuses/{nexus_id}/share/{protocol}", tags(Nexuses))]
 async fn put_node_nexus_share(
     web::Path((node_id, nexus_id, protocol)): web::Path<(
         NodeId,
@@ -82,7 +78,7 @@ async fn put_node_nexus_share(
     RestRespond::result(MessageBus::share_nexus(share).await)
 }
 
-#[delete("/v0", "/nodes/{node_id}/nexuses/{nexus_id}/share", tags(Nexuses))]
+#[delete("/nodes/{node_id}/nexuses/{nexus_id}/share", tags(Nexuses))]
 async fn del_node_nexus_share(
     web::Path((node_id, nexus_id)): web::Path<(NodeId, NexusId)>,
 ) -> Result<JsonUnit, RestError> {

--- a/control-plane/rest/service/src/v0/nodes.rs
+++ b/control-plane/rest/service/src/v0/nodes.rs
@@ -4,12 +4,12 @@ pub(super) fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
     cfg.service(get_nodes).service(get_node);
 }
 
-#[get("/v0", "/nodes", tags(Nodes))]
+#[get("/nodes", tags(Nodes))]
 async fn get_nodes() -> Result<web::Json<Vec<Node>>, RestClusterError> {
     RestRespond::result(MessageBus::get_nodes().await)
         .map_err(RestClusterError::from)
 }
-#[get("/v0", "/nodes/{id}", tags(Nodes))]
+#[get("/nodes/{id}", tags(Nodes))]
 async fn get_node(
     web::Path(node_id): web::Path<NodeId>,
 ) -> Result<web::Json<Node>, RestError> {

--- a/control-plane/rest/service/src/v0/pools.rs
+++ b/control-plane/rest/service/src/v0/pools.rs
@@ -10,26 +10,26 @@ pub(super) fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
         .service(del_pool);
 }
 
-#[get("/v0", "/pools", tags(Pools))]
+#[get("/pools", tags(Pools))]
 async fn get_pools() -> Result<Json<Vec<Pool>>, RestClusterError> {
     RestRespond::result(MessageBus::get_pools(Filter::None).await)
         .map_err(RestClusterError::from)
 }
-#[get("/v0", "/pools/{pool_id}", tags(Pools))]
+#[get("/pools/{pool_id}", tags(Pools))]
 async fn get_pool(
     web::Path(pool_id): web::Path<PoolId>,
 ) -> Result<Json<Pool>, RestError> {
     RestRespond::result(MessageBus::get_pool(Filter::Pool(pool_id)).await)
 }
 
-#[get("/v0", "/nodes/{id}/pools", tags(Pools))]
+#[get("/nodes/{id}/pools", tags(Pools))]
 async fn get_node_pools(
     web::Path(node_id): web::Path<NodeId>,
 ) -> Result<Json<Vec<Pool>>, RestError> {
     RestRespond::result(MessageBus::get_pools(Filter::Node(node_id)).await)
 }
 
-#[get("/v0", "/nodes/{node_id}/pools/{pool_id}", tags(Pools))]
+#[get("/nodes/{node_id}/pools/{pool_id}", tags(Pools))]
 async fn get_node_pool(
     web::Path((node_id, pool_id)): web::Path<(NodeId, PoolId)>,
 ) -> Result<Json<Pool>, RestError> {
@@ -38,7 +38,7 @@ async fn get_node_pool(
     )
 }
 
-#[put("/v0", "/nodes/{node_id}/pools/{pool_id}", tags(Pools))]
+#[put("/nodes/{node_id}/pools/{pool_id}", tags(Pools))]
 async fn put_node_pool(
     web::Path((node_id, pool_id)): web::Path<(NodeId, PoolId)>,
     create: web::Json<CreatePoolBody>,
@@ -47,13 +47,13 @@ async fn put_node_pool(
     RestRespond::result(MessageBus::create_pool(create).await)
 }
 
-#[delete("/v0", "/nodes/{node_id}/pools/{pool_id}", tags(Pools))]
+#[delete("/nodes/{node_id}/pools/{pool_id}", tags(Pools))]
 async fn del_node_pool(
     web::Path((node_id, pool_id)): web::Path<(NodeId, PoolId)>,
 ) -> Result<JsonUnit, RestError> {
     destroy_pool(Filter::NodePool(node_id, pool_id)).await
 }
-#[delete("/v0", "/pools/{pool_id}", tags(Pools))]
+#[delete("/pools/{pool_id}", tags(Pools))]
 async fn del_pool(
     web::Path(pool_id): web::Path<PoolId>,
 ) -> Result<JsonUnit, RestError> {

--- a/control-plane/rest/service/src/v0/replicas.rs
+++ b/control-plane/rest/service/src/v0/replicas.rs
@@ -16,12 +16,12 @@ pub(super) fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
         .service(del_pool_replica_share);
 }
 
-#[get("/v0", "/replicas", tags(Replicas))]
+#[get("/replicas", tags(Replicas))]
 async fn get_replicas() -> Result<Json<Vec<Replica>>, RestClusterError> {
     RestRespond::result(MessageBus::get_replicas(Filter::None).await)
         .map_err(RestClusterError::from)
 }
-#[get("/v0", "/replicas/{id}", tags(Replicas))]
+#[get("/replicas/{id}", tags(Replicas))]
 async fn get_replica(
     web::Path(replica_id): web::Path<ReplicaId>,
 ) -> Result<Json<Replica>, RestError> {
@@ -30,14 +30,14 @@ async fn get_replica(
     )
 }
 
-#[get("/v0", "/nodes/{id}/replicas", tags(Replicas))]
+#[get("/nodes/{id}/replicas", tags(Replicas))]
 async fn get_node_replicas(
     web::Path(node_id): web::Path<NodeId>,
 ) -> Result<Json<Vec<Replica>>, RestError> {
     RestRespond::result(MessageBus::get_replicas(Filter::Node(node_id)).await)
 }
 
-#[get("/v0", "/nodes/{node_id}/pools/{pool_id}/replicas", tags(Replicas))]
+#[get("/nodes/{node_id}/pools/{pool_id}/replicas", tags(Replicas))]
 async fn get_node_pool_replicas(
     web::Path((node_id, pool_id)): web::Path<(NodeId, PoolId)>,
 ) -> Result<Json<Vec<Replica>>, RestError> {
@@ -46,7 +46,6 @@ async fn get_node_pool_replicas(
     )
 }
 #[get(
-    "/v0",
     "/nodes/{node_id}/pools/{pool_id}/replicas/{replica_id}",
     tags(Replicas)
 )]
@@ -66,7 +65,6 @@ async fn get_node_pool_replica(
 }
 
 #[put(
-    "/v0",
     "/nodes/{node_id}/pools/{pool_id}/replicas/{replica_id}",
     tags(Replicas)
 )]
@@ -84,7 +82,7 @@ async fn put_node_pool_replica(
     )
     .await
 }
-#[put("/v0", "/pools/{pool_id}/replicas/{replica_id}", tags(Replicas))]
+#[put("/pools/{pool_id}/replicas/{replica_id}", tags(Replicas))]
 async fn put_pool_replica(
     web::Path((pool_id, replica_id)): web::Path<(PoolId, ReplicaId)>,
     create: web::Json<CreateReplicaBody>,
@@ -97,7 +95,6 @@ async fn put_pool_replica(
 }
 
 #[delete(
-    "/v0",
     "/nodes/{node_id}/pools/{pool_id}/replicas/{replica_id}",
     tags(Replicas)
 )]
@@ -110,7 +107,7 @@ async fn del_node_pool_replica(
 ) -> Result<JsonUnit, RestError> {
     destroy_replica(Filter::NodePoolReplica(node_id, pool_id, replica_id)).await
 }
-#[delete("/v0", "/pools/{pool_id}/replicas/{replica_id}", tags(Replicas))]
+#[delete("/pools/{pool_id}/replicas/{replica_id}", tags(Replicas))]
 async fn del_pool_replica(
     web::Path((pool_id, replica_id)): web::Path<(PoolId, ReplicaId)>,
 ) -> Result<JsonUnit, RestError> {
@@ -118,7 +115,6 @@ async fn del_pool_replica(
 }
 
 #[put(
-    "/v0",
     "/nodes/{node_id}/pools/{pool_id}/replicas/{replica_id}/share/{protocol}",
     tags(Replicas)
 )]
@@ -137,7 +133,6 @@ async fn put_node_pool_replica_share(
     .await
 }
 #[put(
-    "/v0",
     "/pools/{pool_id}/replicas/{replica_id}/share/{protocol}",
     tags(Replicas)
 )]
@@ -152,7 +147,6 @@ async fn put_pool_replica_share(
 }
 
 #[delete(
-    "/v0",
     "/nodes/{node_id}/pools/{pool_id}/replicas/{replica_id}/share",
     tags(Replicas)
 )]
@@ -165,7 +159,7 @@ async fn del_node_pool_replica_share(
 ) -> Result<JsonUnit, RestError> {
     unshare_replica(Filter::NodePoolReplica(node_id, pool_id, replica_id)).await
 }
-#[delete("/v0", "/pools/{pool_id}/replicas/{replica_id}/share", tags(Replicas))]
+#[delete("/pools/{pool_id}/replicas/{replica_id}/share", tags(Replicas))]
 async fn del_pool_replica_share(
     web::Path((pool_id, replica_id)): web::Path<(PoolId, ReplicaId)>,
 ) -> Result<JsonUnit, RestError> {

--- a/control-plane/rest/service/src/v0/volumes.rs
+++ b/control-plane/rest/service/src/v0/volumes.rs
@@ -11,26 +11,26 @@ pub(super) fn configure(cfg: &mut paperclip::actix::web::ServiceConfig) {
         .service(volume_unshare);
 }
 
-#[get("/v0", "/volumes", tags(Volumes))]
+#[get("/volumes", tags(Volumes))]
 async fn get_volumes() -> Result<Json<Vec<Volume>>, RestClusterError> {
     RestRespond::result(MessageBus::get_volumes(Filter::None).await)
         .map_err(RestClusterError::from)
 }
 
-#[get("/v0", "/volumes/{volume_id}", tags(Volumes))]
+#[get("/volumes/{volume_id}", tags(Volumes))]
 async fn get_volume(
     web::Path(volume_id): web::Path<VolumeId>,
 ) -> Result<Json<Volume>, RestError> {
     RestRespond::result(MessageBus::get_volume(Filter::Volume(volume_id)).await)
 }
 
-#[get("/v0", "/nodes/{node_id}/volumes", tags(Volumes))]
+#[get("/nodes/{node_id}/volumes", tags(Volumes))]
 async fn get_node_volumes(
     web::Path(node_id): web::Path<NodeId>,
 ) -> Result<Json<Vec<Volume>>, RestError> {
     RestRespond::result(MessageBus::get_volumes(Filter::Node(node_id)).await)
 }
-#[get("/v0", "/nodes/{node_id}/volumes/{volume_id}", tags(Volumes))]
+#[get("/nodes/{node_id}/volumes/{volume_id}", tags(Volumes))]
 async fn get_node_volume(
     web::Path((node_id, volume_id)): web::Path<(NodeId, VolumeId)>,
 ) -> Result<Json<Volume>, RestError> {
@@ -39,7 +39,7 @@ async fn get_node_volume(
     )
 }
 
-#[put("/v0", "/volumes/{volume_id}", tags(Volumes))]
+#[put("/volumes/{volume_id}", tags(Volumes))]
 async fn put_volume(
     web::Path(volume_id): web::Path<VolumeId>,
     create: web::Json<CreateVolumeBody>,
@@ -48,7 +48,7 @@ async fn put_volume(
     RestRespond::result(MessageBus::create_volume(create).await)
 }
 
-#[delete("/v0", "/volumes/{volume_id}", tags(Volumes))]
+#[delete("/volumes/{volume_id}", tags(Volumes))]
 async fn del_volume(
     web::Path(volume_id): web::Path<VolumeId>,
 ) -> Result<JsonUnit, RestError> {
@@ -59,7 +59,7 @@ async fn del_volume(
         .map(JsonUnit::from)
 }
 
-#[put("/v0", "/volumes/{volume_id}/share/{protocol}", tags(Volumes))]
+#[put("/volumes/{volume_id}/share/{protocol}", tags(Volumes))]
 async fn volume_share(
     web::Path((volume_id, protocol)): web::Path<(VolumeId, NexusShareProtocol)>,
 ) -> Result<Json<String>, RestError> {
@@ -86,7 +86,7 @@ async fn volume_share(
     }
 }
 
-#[delete("/v0", "/volumes{volume_id}/share", tags(Volumes))]
+#[delete("/volumes{volume_id}/share", tags(Volumes))]
 async fn volume_unshare(
     web::Path(volume_id): web::Path<VolumeId>,
 ) -> Result<JsonUnit, RestError> {

--- a/control-plane/rest/src/versions/v0.rs
+++ b/control-plane/rest/src/versions/v0.rs
@@ -570,7 +570,7 @@ impl ActixRestClient {
 )]
 #[derive(Debug)]
 pub struct RestError {
-    inner: BusError,
+    inner: ReplyError,
 }
 
 /// Rest Cluster Error
@@ -655,7 +655,7 @@ impl RestError {
                     RestJsonErrorKind::Deserialize,
                     &details,
                 );
-                HttpResponse::InternalServerError().json(error)
+                HttpResponse::BadRequest().json(error)
             }
             ReplyErrorKind::Internal => {
                 let error =
@@ -770,8 +770,8 @@ impl ResponseError for RestError {
         self.get_resp_error()
     }
 }
-impl From<BusError> for RestError {
-    fn from(inner: BusError) -> Self {
+impl From<ReplyError> for RestError {
+    fn from(inner: ReplyError) -> Self {
         Self {
             inner,
         }
@@ -783,7 +783,7 @@ impl From<RestError> for HttpResponse {
     }
 }
 
-/// Respond using a message bus response Result<Response,BusError>
+/// Respond using a message bus response Result<Response,ReplyError>
 /// In case of success the Response is sent via the body of a HttpResponse with
 /// StatusCode OK.
 /// Otherwise, the RestError is returned, also as a HttpResponse/ResponseError.
@@ -798,8 +798,8 @@ impl<T> Display for RestRespond<T> {
     }
 }
 impl<T: Serialize> RestRespond<T> {
-    /// Respond with a Result<T, BusError>
-    pub fn result(from: Result<T, BusError>) -> Result<Json<T>, RestError> {
+    /// Respond with a Result<T, ReplyError>
+    pub fn result(from: Result<T, ReplyError>) -> Result<Json<T>, RestError> {
         match from {
             Ok(v) => Ok(Json::<T>(v)),
             Err(e) => Err(e.into()),
@@ -810,8 +810,8 @@ impl<T: Serialize> RestRespond<T> {
         Ok(Json(object))
     }
 }
-impl<T> From<Result<T, BusError>> for RestRespond<T> {
-    fn from(src: Result<T, BusError>) -> Self {
+impl<T> From<Result<T, ReplyError>> for RestRespond<T> {
+    fn from(src: Result<T, ReplyError>) -> Self {
         RestRespond(src.map_err(RestError::from))
     }
 }

--- a/nix/pkgs/control-plane/cargo-project.nix
+++ b/nix/pkgs/control-plane/cargo-project.nix
@@ -31,7 +31,7 @@ let
   buildProps = rec {
     name = "control-plane-${version}";
     #cargoSha256 = "0000000000000000000000000000000000000000000000000000";
-    cargoSha256 = "1bg09ws384di6kb896ynm4na0n10v3k823j6xqvdxpxz5ybgvhba";
+    cargoSha256 = "0ipq2bzlgzmvx0mshvsq81nckkj852dgnr1by882sx82s8xwqp75";
     inherit version;
 
     src = whitelistSource ../../../. [


### PR DESCRIPTION
- refactor(rest): simplify the openapi macros

  Simplify the openapi macros which at the moment have the full and relative
   path for a handler. This is possible thanks to the paperclip change which
   trims the base path of all handlers if it matches the api base path.
  
  This means we can now use scopes to avoid repeating the base path on each
   handler's macro.

- fix(errors): map actix builtin errors

  The Path and Json body validation are handle by the actix; in case of
   error we should make it to our own error types.
  Now that we have scopes we can easily add an error to the v0 scope.
  Example of Invalid JSON bodies error:
  400: Bad Request
  {
    "error": "Deserialize",
    "details": "Json deserialize error: missing field `size` at line 4 column 1"
  }